### PR TITLE
Fix bad docker image for ffmpeg tests

### DIFF
--- a/python/sample4_ffmpeg.py
+++ b/python/sample4_ffmpeg.py
@@ -40,6 +40,7 @@ try:
     # constant.
     # Task constants are the main way of controlling a task's behaviour
     task.constants['DOCKER_REPO'] = 'jrottenberg/ffmpeg'
+    task.constants['DOCKER_TAG'] = 'ubuntu'
     task.constants['DOCKER_CMD'] = ffmpeg_cmd
     # task.constants['DOCKER_CMD'] = "sleep 3600"
 


### PR DESCRIPTION
The last docker image from `jrottenberg/ffmpeg` is broken for ffmpeg tests.
This pull request fix the ffmpeg tests to use an older docker image based on ubuntu.